### PR TITLE
Remove references to signalfx-metadata

### DIFF
--- a/group/Infrastructure (Telegraf).json
+++ b/group/Infrastructure (Telegraf).json
@@ -43,7 +43,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).mean(by=['host']).mean(over='1m').top(count=10).publish(label='A')",
+        "programText": "A = data('cpu.utilization', filter=filter('agent', 'telegraf')).mean(by=['host']).mean(over='1m').top(count=10).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -338,7 +338,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('memory.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).publish(label='A')",
+        "programText": "A = data('memory.utilization', filter=filter('agent', 'telegraf')).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -778,7 +778,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).mean(by=['host']).publish(label='A', enable=False)\nB = (A).max().publish(label='B')\nC = (A).min().publish(label='C')\nD = (A).percentile(pct=10).publish(label='D')\nE = (A).percentile(pct=50).publish(label='E')\nF = (A).percentile(pct=90).publish(label='F')",
+        "programText": "A = data('cpu.utilization', filter=filter('agent', 'telegraf')).mean(by=['host']).publish(label='A', enable=False)\nB = (A).max().publish(label='B')\nC = (A).min().publish(label='C')\nD = (A).percentile(pct=10).publish(label='D')\nE = (A).percentile(pct=50).publish(label='E')\nF = (A).percentile(pct=90).publish(label='F')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -825,7 +825,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).publish(label='A')",
+        "programText": "A = data('cpu.utilization', filter=filter('agent', 'telegraf')).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1090,7 +1090,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (A).publish(label='B')",
+        "programText": "A = data('disk.utilization', filter=filter('agent', 'telegraf')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (A).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1290,7 +1290,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (100 - A).publish(label='B')",
+        "programText": "A = data('disk.utilization', filter=filter('agent', 'telegraf')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (100 - A).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1702,7 +1702,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('memory.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
+        "programText": "A = data('memory.utilization', filter=filter('agent', 'telegraf')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1883,7 +1883,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata') and filter('agent', 'telegraf')).publish(label='A')",
+        "programText": "A = data('cpu.utilization', filter=filter('agent', 'telegraf')).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2046,7 +2046,7 @@
         "customProperties": null,
         "description": "Dashboards about infrastructure as measured by Telegraf.",
         "discoveryOptions": {
-          "query": "plugin:signalfx-metadata AND sf_metric:cpu.utilization AND agent:telegraf",
+          "query": "sf_metric:cpu.utilization AND agent:telegraf",
           "selectors": [
             "agent:telegraf",
             "sf_key:host"
@@ -2162,7 +2162,7 @@
         "customProperties": null,
         "description": "Host running Telegraf",
         "discoveryOptions": {
-          "query": "plugin:signalfx-metadata AND sf_metric:cpu.utilization AND agent:telegraf",
+          "query": "sf_metric:cpu.utilization AND agent:telegraf",
           "selectors": [
             "agent:telegraf",
             "_exists_:host"

--- a/group/Infrastructure.json
+++ b/group/Infrastructure.json
@@ -1003,7 +1003,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.utilization', filter=filter('plugin', 'signalfx-metadata')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (100 - A).publish(label='B')",
+        "programText": "A = data('disk.utilization').mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (100 - A).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1174,7 +1174,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata')).publish(label='A')",
+        "programText": "A = data('cpu.utilization').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1506,7 +1506,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata')).publish(label='A')",
+        "programText": "A = data('cpu.utilization').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1817,7 +1817,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.utilization', filter=filter('plugin', 'signalfx-metadata')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (A).publish(label='B')",
+        "programText": "A = data('disk.utilization').mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (A).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2045,7 +2045,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata')).publish(label='A')",
+        "programText": "A = data('cpu.utilization').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2188,7 +2188,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata') and (not filter('agent', '*'))).mean(by=['host']).mean(over='1m').top(count=10).publish(label='A')",
+        "programText": "A = data('cpu.utilization', filter=(not filter('agent', '*'))).mean(by=['host']).mean(over='1m').top(count=10).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2722,7 +2722,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.utilization', filter=filter('plugin', 'signalfx-metadata')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (100 - A).publish(label='B')",
+        "programText": "A = data('disk.utilization').mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (100 - A).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2769,7 +2769,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('memory.utilization', filter=filter('plugin', 'signalfx-metadata')).publish(label='A')",
+        "programText": "A = data('memory.utilization').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2845,7 +2845,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata')).publish(label='A')",
+        "programText": "A = data('cpu.utilization').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2971,7 +2971,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('plugin', 'signalfx-metadata') and (not filter('agent', '*'))).mean(by=['host']).publish(label='A', enable=False)\nB = (A).max().publish(label='B')\nC = (A).min().publish(label='C')\nD = (A).percentile(pct=10).publish(label='D')\nE = (A).percentile(pct=50).publish(label='E')\nF = (A).percentile(pct=90).publish(label='F')",
+        "programText": "A = data('cpu.utilization', filter=(not filter('agent', '*'))).mean(by=['host']).publish(label='A', enable=False)\nB = (A).max().publish(label='B')\nC = (A).min().publish(label='C')\nD = (A).percentile(pct=10).publish(label='D')\nE = (A).percentile(pct=50).publish(label='E')\nF = (A).percentile(pct=90).publish(label='F')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3029,7 +3029,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.utilization', filter=filter('plugin', 'signalfx-metadata')).mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (A).publish(label='B')",
+        "programText": "A = data('disk.utilization').mean(by=['plugin_instance']).publish(label='A', enable=False)\nB = (A).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3170,7 +3170,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('memory.utilization', filter=filter('plugin', 'signalfx-metadata')).publish(label='A')",
+        "programText": "A = data('memory.utilization').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3296,7 +3296,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('memory.utilization', filter=filter('plugin', 'signalfx-metadata') and (not filter('agent', '*'))).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
+        "programText": "A = data('memory.utilization', filter=(not filter('agent', '*'))).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3459,7 +3459,7 @@
         "customProperties": null,
         "description": "Windows host system information",
         "discoveryOptions": {
-          "query": "plugin:signalfx-metadata AND sf_metric:cpu.utilization AND NOT _exists_:agent AND host_kernel_name:windows",
+          "query": "sf_metric:cpu.utilization AND NOT _exists_:agent AND host_kernel_name:windows",
           "selectors": [
             "_exists_:host"
           ]
@@ -3572,7 +3572,7 @@
         "customProperties": null,
         "description": "",
         "discoveryOptions": {
-          "query": "plugin:signalfx-metadata AND _exists_:host",
+          "query": "_exists_:host",
           "selectors": [
             "sf_key:host"
           ]
@@ -3687,7 +3687,7 @@
         "customProperties": null,
         "description": "",
         "discoveryOptions": {
-          "query": "plugin:signalfx-metadata AND sf_metric:cpu.utilization AND NOT _exists_:agent AND NOT host_kernel_name:windows",
+          "query": "sf_metric:cpu.utilization AND NOT _exists_:agent AND NOT host_kernel_name:windows",
           "selectors": [
             "_exists_:host"
           ]
@@ -3730,20 +3730,12 @@
         "DyVKoZTAgAA",
         "DyVKwOVAgAA"
       ],
-      "description": "Dashboards about infrastructure as measured by collectd and the SignalFx collectd plugin. ",
+      "description": "Dashboards about infrastructure as measured by the SignalFx Smart Agent. ",
       "email": null,
       "id": "DiVWWylAYD4",
       "importQualifiers": [
         {
-          "filters": [
-            {
-              "not": false,
-              "property": "plugin",
-              "values": [
-                "signalfx-metadata"
-              ]
-            }
-          ],
+          "filters": [],
           "metric": "cpu.utilization"
         }
       ],

--- a/navigators/Hosts/collectd hosts.json
+++ b/navigators/Hosts/collectd hosts.json
@@ -231,7 +231,7 @@
           "valueFormat" : "AlertSeverity",
           "valueLabel" : "Most severe alert"
         } ],
-        "mtsQuery" : "plugin:signalfx-metadata AND _exists_:host",
+        "mtsQuery" : "_exists_:host",
         "propertyColumns" : [ [ {
           "header" : "Memory",
           "properties" : [ "host_mem_total" ]


### PR DESCRIPTION
This plugin type is obsolete and our newer stuff will not use it